### PR TITLE
Colormap 'Greys' is abnormal value

### DIFF
--- a/lab-11-X-mnist_cnn_low_memory.py
+++ b/lab-11-X-mnist_cnn_low_memory.py
@@ -161,7 +161,7 @@ print("Prediction: ", sess.run(
     tf.argmax(hypothesis, 1), {X: mnist.test.images[r:r + 1], keep_prob: 1}))
 
 # plt.imshow(mnist.test.images[r:r + 1].
-#           reshape(28, 28), cmap='Greys', interpolation='nearest')
+#           reshape(28, 28), cmap='Gray', interpolation='nearest')
 # plt.show()
 
 '''


### PR DESCRIPTION
if run this code, python raise ValueError: Colormap grays is not recognized. Possible values are:...

Gray is right value for param cmap